### PR TITLE
Add the ability to supply Handlebars helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Gulp 3 plugin for building out files for deployment. Good for swapping environmental variables like Google Analytics IDs, or just compiling static HTML files.
 
-`gulp-build` uses HandleBars for templates, and supports partials and layouts.
+`gulp-build` uses HandleBars for templates, and supports helpers, partials, and layouts.
 
 **Version `0.5.0` was a big update. I moved away from using Underscore templates, and have added support for partials and layouts. Both partials and layouts must be passed in as strings, but a future update will bring support for file glob'ing.**
 
@@ -25,6 +25,31 @@ gulp.task('build', function() {
       .pipe(gulp.dest('dist'))
 });
 ```
+
+With helpers:
+
+```javascript
+var build = require('gulp-build');
+
+var options = {
+  helpers: [{
+    name: 'addition',
+    fn: function (a, b) { return a + b; }
+  }]
+};
+
+gulp.task('build', function() {
+  gulp.src('pages/*.html')
+      .pipe(build({ title: 'Some page' }, options))
+      .pipe(gulp.dest('dist'))
+});
+
+```
+
+Helpers are regular Handlebars helpers or block helpers that your layout, partials, and templates can call.
+
+For more information on Handlebars helpers, see http://handlebarsjs.com/#helpers and http://handlebarsjs.com/block_helpers.html.
+
 
 With partials and a layout:
 

--- a/index.js
+++ b/index.js
@@ -5,7 +5,8 @@ var hbs = require('handlebars');
 module.exports = function(data, config) {
 	var options = _.extend({
 		layout: null,
-		partials: []
+		partials: [],
+		helpers: []
 	}, config);
 
 	data = data || {};
@@ -13,6 +14,12 @@ module.exports = function(data, config) {
 	var build = function(file, encoding, callback) {
 		var fileContents = file.contents.toString();
 		var template = '';
+
+		if (options.helpers.length > 0) {
+			_.each(options.helpers, function(helper) {
+				hbs.registerHelper(helper.name, helper.fn);
+			});
+		}
 
 		if (options.partials.length > 0) {
 			_.each(options.partials, function(partial) {

--- a/test/test.js
+++ b/test/test.js
@@ -94,4 +94,118 @@ describe('gulp-build', function() {
 
 		stream.write(fakeFile.file);
 	});
+
+	it('should compile with helpers', function (done) {
+		var stream = build({ name: 'Jack' }, {
+			helpers: [
+				{
+					name: 'add',
+					fn: function (a, b) {return a + b;}
+				}
+			]
+		});
+		var fakeFile = getFile(new Buffer('<p>1 + 2 is definitely equal to {{add 1 2}}.</p>'), '<p>1 + 2 is definitely equal to 3.</p>');
+
+		stream.on('data', function(newFile) {
+			should.exist(newFile);
+			should.exist(newFile.path);
+			should.exist(newFile.relative);
+			should.exist(newFile.contents);
+			Buffer.isBuffer(newFile.contents).should.be.true
+			newFile.contents.toString().should.equal(fakeFile.expected);
+			done();
+		});
+
+		stream.write(fakeFile.file);
+	});
+
+	it('should compile with partials that use the provided helpers', function (done) {
+		var stream = build({ name: 'Jack' }, {
+			helpers: [
+				{
+					name: 'add',
+					fn: function (a, b) {return a + b;}
+				}
+			],
+			partials: [
+				{
+					name: 'addition',
+					tpl: '<p>1 + 2 is definitely equal to {{add 1 2}}.</p>'
+				}
+			]
+		});
+		var fakeFile = getFile(new Buffer('<div>Fact: {{> addition}}</div>'), '<div>Fact: <p>1 + 2 is definitely equal to 3.</p></div>');
+
+		stream.on('data', function(newFile) {
+			should.exist(newFile);
+			should.exist(newFile.path);
+			should.exist(newFile.relative);
+			should.exist(newFile.contents);
+			Buffer.isBuffer(newFile.contents).should.be.true
+			newFile.contents.toString().should.equal(fakeFile.expected);
+			done();
+		});
+
+		stream.write(fakeFile.file);
+	});
+
+	it('should compile with a layout that use the provided helpers', function (done) {
+		var stream = build({ name: 'Jack' }, {
+			layout: '<div><p>We know that 1 + 2 is {{add 1 2}}.</p>{{> body}}</div>',
+			helpers: [
+				{
+					name: 'add',
+					fn: function (a, b) {return a + b;}
+				}
+			]
+		});
+		var fakeFile = getFile(new Buffer('<p>But what is 1 - 2?</p>'), '<div><p>We know that 1 + 2 is 3.</p><p>But what is 1 - 2?</p></div>');
+
+		stream.on('data', function(newFile) {
+			should.exist(newFile);
+			should.exist(newFile.path);
+			should.exist(newFile.relative);
+			should.exist(newFile.contents);
+			Buffer.isBuffer(newFile.contents).should.be.true
+			newFile.contents.toString().should.equal(fakeFile.expected);
+			done();
+		});
+
+		stream.write(fakeFile.file);
+	});
+
+	it('should compile with a layout and partials that use the provided helpers', function (done) {
+		var stream = build({ name: 'Jack' }, {
+			layout: '<div><p>We know that 1 + 2 is {{add 1 2}}.</p>{{> body}}</div>',
+			helpers: [
+				{
+					name: 'add',
+					fn: function (a, b) {return a + b;}
+				},
+				{
+					name: 'subtract',
+					fn: function (a, b) {return a - b;}
+				}
+			],
+			partials: [
+				{
+					name: 'subtraction',
+					tpl: '<p>Well, it turns out that 1 - 2 is {{subtract 1 2}}.</p>'
+				}
+			]
+		});
+		var fakeFile = getFile(new Buffer('<p>But what is 1 - 2?</p>{{> subtraction}}'), '<div><p>We know that 1 + 2 is 3.</p><p>But what is 1 - 2?</p><p>Well, it turns out that 1 - 2 is -1.</p></div>');
+
+		stream.on('data', function(newFile) {
+			should.exist(newFile);
+			should.exist(newFile.path);
+			should.exist(newFile.relative);
+			should.exist(newFile.contents);
+			Buffer.isBuffer(newFile.contents).should.be.true
+			newFile.contents.toString().should.equal(fakeFile.expected);
+			done();
+		});
+
+		stream.write(fakeFile.file);
+	});
 });


### PR DESCRIPTION
I implemented a simple addition to gulp-build's functionality so that it allow users to supply helpers to the build process. It seemed like a reasonable augmentation since you decided to go with Handlebars.

I've included tests and updated the README, trying to keep to the same testing conventions and documentation style you used.
